### PR TITLE
[RT-734] Update image tag to major floating tag & add release steps

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,17 +7,16 @@ orbs:
 workflows:
   main-workflow:
     jobs:
-      - preprocess-helm:
-          context: org-global
+      - check-verison-bump
       - package-helm-chart:
           context: org-global
-          publish: false
+          publish: true
           filters:
             branches:
               only:
                 - main
           requires:
-            - preprocess-helm
+            - check-verison-bump
       - package-helm-chart:
           name: dry-run-package
           publish: false
@@ -28,16 +27,16 @@ workflows:
                 - main
                 - canary
           requires:
-            - preprocess-helm
+            - check-verison-bump
       - package-cloud-helm-chart:
-          publish: false
+          publish: true
           context: org-global
           filters:
             branches:
               only:
                 - main
           requires:
-            - preprocess-helm
+            - check-verison-bump
       - package-cloud-helm-chart:
           name: dry-run-package-cloud
           publish: false
@@ -48,27 +47,36 @@ workflows:
                 - main
                 - canary
           requires:
-            - preprocess-helm
+            - check-verison-bump
 
 jobs:
-  preprocess-helm:
+  check-verison-bump:
     docker:
-      - image: cimg/base:2021.04
+      - image: cimg/base:stable
     resource_class: medium
     steps:
       - checkout
-      - attach_workspace:
-          at: .
-      - run:
-          name: Preprocess Helm chart with the semantic version
-          command: ./do preprocess-helm
-      - run: ./do install-helm
-      - run: helm lint .
-      - persist_to_workspace:
-          root: .
-          paths:
-            - .
-      - notify_failing_main
+      - when:
+          condition:
+            equal: [ << pipeline.git.branch >>, main ]
+          steps:
+            - run: |
+                if [ "$(./do version)" == "$(git show HEAD^:Chart.yaml | grep version | sed -nE 's/.*"(.*)".*/\1/p')" ]; then
+                  exit 1
+                else
+                  exit 0
+                fi
+      - when:
+          condition:
+            not:
+              equal: [ << pipeline.git.branch >>, main]
+          steps:
+            - run: |
+                if [ "$(./do version)" == "$(git show main:Chart.yaml | grep version | sed -nE 's/.*"(.*)".*/\1/p')" ]; then
+                  exit 1
+                else
+                  exit 0
+                fi
 
   package-helm-chart:
     docker:
@@ -93,6 +101,7 @@ jobs:
           paths:
             - helm-package
       - notify_failing_main
+
   package-cloud-helm-chart:
     docker:
       - image: cimg/python:3.10

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: <<semantic_version>> # set by CI
-appVersion: 3.0.0
+version: "100.0.0"
+appVersion: "3"

--- a/do
+++ b/do
@@ -1,35 +1,11 @@
 #!/usr/bin/env bash
 set -eu -o pipefail
 
-_version=1.0.${CIRCLE_BUILD_NUM-0}-$(git rev-parse --short HEAD 2>/dev/null || echo latest)
-
 # This variable is used, but shellcheck can't tell.
 # shellcheck disable=SC2034
 help_version="Print version"
 version() {
-    echo "$_version"
-}
-
-# This variable is used, but shellcheck can't tell.
-# shellcheck disable=SC2034
-help_preprocess_helm="Used by CI to preprocess the Helm chart with the semantic version"
-preprocess-helm() {
-    set -x
-
-    if [[ -f ./target/version.txt ]]; then
-        ver=$(<./target/version.txt)
-    else
-        ver=$(version)
-    fi
-
-    # Remove the git hash from the version to generate a release SemVer
-    # Note that the MINOR version is the build number
-    semver=$(echo "${ver}" | cut -f1 -d"-")
-
-    # Below will preprocess the Helm chart files with substitutions.
-    # <<semantic_version>> will be replaced with the SemVer,
-    # and <<image_tag>> will be replaced with the image tag
-    sed -i "s/<<semantic_version>>.*/\"${semver}\"/g" ./*.yaml
+    grep version Chart.yaml | sed -nE 's/.*"(.*)".*/\1/p'
 }
 
 # This variable is used, but shellcheck can't tell.

--- a/values.yaml
+++ b/values.yaml
@@ -12,7 +12,7 @@ agent:
     registry: ""
     repository: "circleci/container-agent"
     pullPolicy: Always
-    tag: "edge"
+    tag: "3"
 
   pullSecrets: []
 


### PR DESCRIPTION
Update the default agent image tag to use the floating major version (3 at the time of this PR) 

Also add a check to ensure the chart version is bumped when updating to avoid overwriting old versions