### PR TITLE
[RT-872] Use the custom service account name if present

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "100.0.0"
+version: "100.0.1"
 appVersion: "3"

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,11 @@
+# Container Agent Helm Chart Changelog
+
+This is the Container Agent Helm Chart changelog
+
+## 100.0.1
+
+Set custom service account even if `create` is set to `false` ([PR #5](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/5))
+
+## 100.0.0 
+
+Initial release of helm chart

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -54,7 +54,11 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 RBAC names
 */}}
 {{- define "container-agent.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
 {{- default (include "container-agent.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name}}
+{{- end }}
 {{- end }}
 
 {{- define "container-agent.roleName" -}}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -24,9 +24,7 @@ spec:
         - {{ toYaml . }}
       {{- end}}
     {{- end }}
-    {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "container-agent.serviceAccountName" . }}
-    {{- end }}
     {{- if .Values.agent.podSecurityContext }}
       securityContext: {{- toYaml .Values.agent.podSecurityContext | nindent 8 }}
     {{- end }}

--- a/templates/rbac.yaml
+++ b/templates/rbac.yaml
@@ -62,7 +62,7 @@ roleRef:
   kind: ClusterRole
   name: {{ include "container-agent.clusterRoleName" . }}
 {{- end }} # if .Values.agent.autodetectPlatform
-{{- end }} # if rbac.create
+{{- end }}
 {{- if .Values.logging.rbac.create }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
We allow a user to specify their own service account rather than having one created by the chart but due to a template bug this name was not getting passed to the deployment which means the `default` service account is mounted.

This PR means the service account will always be templated, with a default value of `default` if create is turned off & no service account name is set

## Testing

The change was manually tested with `helm template` to verify the expected output (Shown below)

### Before

The relevant snippet from the rendered helm template

```    
  spec:
      terminationGracePeriodSeconds: 18300
      volumes:
        - name: taskpod-config
          configMap:
            name: yeah-container-agent
```

### After

```    
  spec:
      serviceAccountName: custom-name
      terminationGracePeriodSeconds: 18300
      volumes:
        - name: taskpod-config
          configMap:
            name: yeah-container-agent
```
