### PR TITLE
[RT-1014] Use new runner agent repo in values.yaml

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "100.0.1"
+version: "101.0.0"
 appVersion: "3"

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 This is the Container Agent Helm Chart changelog
 
+# 101.0.0
+
+Update default image repository to `circleci/runner-agent`
+
 ## 100.0.1
 
 Set custom service account even if `create` is set to `false` ([PR #5](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/5))

--- a/values.yaml
+++ b/values.yaml
@@ -10,9 +10,9 @@ agent:
 
   image:
     registry: ""
-    repository: "circleci/container-agent"
+    repository: "circleci/runner-agent"
     pullPolicy: Always
-    tag: "3"
+    tag: "kubernetes-3"
 
   pullSecrets: []
 


### PR DESCRIPTION
We are migrating the runner agent image repository as part of the unified runner work. This PR updates the default repository used in the helm chart to the new repository