### PR TITLE
[RT-1014] Remove command from agent pod spec to use command specified in the image Dockerfile

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.0.0"
+version: "101.0.1"
 appVersion: "3"

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 This is the Container Agent Helm Chart changelog
 
+# 101.0.1
+
+Remove command from agent pod spec to use command specified in the image Dockerfile
+
 # 101.0.0
 
 Update default image repository to `circleci/runner-agent`

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -37,7 +37,6 @@ spec:
             name: {{ include "container-agent.fullname" . }}
       containers:
         - name: {{ .Chart.Name }}
-          command: ["./container-agent"]
           {{- with .Values.agent.image }}
           image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}:{{ .tag }}"
           {{- end }}


### PR DESCRIPTION
We already specify the correct startup command in the [Dockerfile](https://hub.docker.com/layers/circleci/runner-agent/kubernetes-edge/images/sha256-5741db6927fd13f4de099012ad6a22463f664747fef9149dc6e27b984dc69fea?context=repo) so we do not need to override this in the pod spec