### PR TITLE
do not use a collection for role and cluster role

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.0.2"
+version: "101.0.3"
 appVersion: "3"

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,11 @@
 
 This is the Container Agent Helm Chart changelog
 
-# 101.0.2
+# 101.0.3
+
+Revert breaking change in 101.2 that required a list for roles and cluster roles
+                                       
+# 101.0.2                              
 
 Break RBAC template into two seperate template files, cleanup whitespace
 

--- a/do
+++ b/do
@@ -39,8 +39,19 @@ provision-test() {
 
     echo 'Dry run the Helm chart'
     helm upgrade --install --dry-run container-agent container-agent/container-agent \
-        --set "agent.image.tag=edge" \
-        --set "agent.nodeSelector.kubernetes\.io/arch=amd64"
+        --set "agent.name=dry-run" \
+        --set "agent.image.tag=kubernetes-edge" \
+        --set "agent.nodeSelector.kubernetes\.io/arch=amd64" \
+        --set "agent.rbac.role.name=TestRole" \
+        --set "agent.rbac.role.binding=TestRole" \
+        --set "agent.pullSecrets[0].name=regcred" \
+        --set "agent.image.repository=circleci/runner-agent" \
+        --set "agent.terminationGracePeriodSeconds=60" \
+        --set "agent.nodeSelector.kubernetes\.io/arch=arm64" \
+        --set "rbac.clusterRoleBinding.name=TestClusterRole" \
+        --set "rbac.clusterRole.name=TestClusterRole" \
+        --set "logging.image.repository=circleci/logging-collector" \
+        --set "logging.image.tag=edge"
 }
 
 # This variable is used, but shellcheck can't tell.

--- a/templates/clusterrole.yaml
+++ b/templates/clusterrole.yaml
@@ -28,7 +28,7 @@ roleRef:
   kind: ClusterRole
   name: {{ $name }}
 
-{{- range $clusterRole := .Values.rbac.clusterRoles }}
+{{- $clusterRole := .Values.rbac.clusterRole }}
 {{- if $clusterRole.rules }}
 {{- $name := join "-" (compact (list $fullname $clusterRole.name )) }}
 ---
@@ -52,6 +52,5 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: {{ $name }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/templates/role.yaml
+++ b/templates/role.yaml
@@ -35,7 +35,7 @@ roleRef:
   kind: Role
   name: {{ $name }}
 
-{{- range $role := .Values.rbac.roles }}
+{{- $role := .Values.rbac.role }}
 {{- if $role.rules }}
 {{- $name := join "-" (compact (list $fullname $role.name )) }}
 ---
@@ -60,7 +60,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: {{ $name }}
-{{- end }}
 {{- end }}
 {{- end }}
 

--- a/values.yaml
+++ b/values.yaml
@@ -205,14 +205,14 @@ serviceAccount:
 # Kubernetes Roles Based Access Control settings
 rbac:
   create: true
-  roles:
-    - name: ""
-      rules: []
-      namespace: ""
-  clusterRoles:
-    - name: ""
-      rules: []
-      namespace: ""
+  role:
+    name: ""
+    rules: []
+    namespace: ""
+  clusterRole:
+    name: ""
+    rules: []
+    namespace: ""
 
 # Configuration values for the logging containers.
 # These containers run alongside service containers and stream their logs to the CircleCI UI


### PR DESCRIPTION
Fix a breaking change to the chart values that used a collection for declaring multiple roles and clusterroles. 

Update provision test to include the option also used by our smoke tests