### PR TITLE
[RT-1172] Add hash option in image parameters

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.0.5"
+version: "101.0.6"
 appVersion: "3"

--- a/README.md
+++ b/README.md
@@ -64,8 +64,10 @@ The following tables list the configurable parameters of the `container-agent` h
 | agent.replicaCount                          | Number of container agents to deploy                    | `1`                        |
 | agent.image.registry                        | Agent image registry                                    | `""`                       |
 | agent.image.repository                      | Agent image repository                                  | `circleci/container-agent` |
-| agent.pullPolicy                            | Agent image pull policy                                 | `IfNotPresent`             |
-| agent.tag                                   | Agent image tag                                         | `latest`                   |
+| agent.image.repository                      | Agent image tag                                         | `kubernetes-3`             |
+| agent.image.digest                          | Agent image digest (NOTE: Overrides tag)                | `""`                       |
+| agent.image.pullPolicy                      | Agent image pull policy                                 | `Always`                   |
+| agent.forceUpdate                           | Force a rolling update of the agent deployment          | `false`                    |
 | agent.pullSecrets                           | Secret objects container private registry credentials   | `[]`                       |
 | agent.matchLabels                           | Match labels used on agent pods                         | `app: container-agent`     |
 | agent.podAnnotations                        | Extra annotations addded to agent pods                  | `{}`                       |

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,11 @@
 
 This is the Container Agent Helm Chart changelog
 
+# 101.0.6
+
+- Add `digest` paramater in `image` settings
+- Add `forceUpdate` option
+
 # 101.0.5
 
 - Fix `logging-collector` RBAC permissions

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -14,6 +14,9 @@ spec:
       labels: {{- toYaml .Values.agent.matchLabels | nindent 8 }}
       annotations:
         checksum/config: {{ .Values.agent.resourceClasses | toString | sha256sum }}
+        {{- if .Values.agent.forceUpdate }}
+        timestamp: {{ now | quote }}
+        {{- end }}
       {{- range $key, $value := .Values.agent.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
@@ -38,7 +41,11 @@ spec:
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.agent.image }}
+          {{- if .digest }}
+          image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}@sha256:{{ .digest }}"
+          {{- else }}
           image: "{{- if .registry -}}{{ .registry }}/{{- end -}}{{ .repository }}:{{ .tag }}"
+          {{- end }}
           {{- end }}
           imagePullPolicy: {{ .Values.agent.image.pullPolicy }}
         {{- if .Values.agent.containerSecurityContext }}

--- a/values.yaml
+++ b/values.yaml
@@ -8,11 +8,13 @@
 agent:
   replicaCount: 1
 
+  # Agent image settings. NOTE: Setting an image digest will take precedence over the image tag
   image:
     registry: ""
     repository: "circleci/runner-agent"
     pullPolicy: Always
     tag: "kubernetes-3"
+    digest: ""
 
   pullSecrets: []
 
@@ -27,6 +29,9 @@ agent:
 
   # Security Context policies for agent containers
   containerSecurityContext: {}
+
+  # Force a rolling update of the agent deployment
+  forceUpdate: false
 
   # Liveness and readiness probe values
   # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes


### PR DESCRIPTION
## Background

`helm` does not support an option to force a release to trigger a rolling deployment. This means that if the edge image has been updated but no further changes have been made the new image is not automatically deployed to the cluster. As we only tag the latest development images with `edge` we can't directly specify a version to get around this

## Changes

This PR adds a `hash` field which allows for the image hash to be directly specified. This ensures the latest version of the agent is always deployed when doing a `helm` release