### PR TITLE
Fix default logging collector image tag [RT-1215]

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.0.7"
+version: "101.0.8"
 appVersion: "3"

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 This is the Container Agent Helm Chart changelog
 
+# 101.0.8
+
+- [#20](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/20) Use the current major release `3` tag instead of the rolling `edge` tag for the logging-collector image
+
 # 101.0.7
 
 - Update README with new parameters & add some documentation links to `values.yaml`

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -14,3 +14,33 @@ tests:
       - equal:
           path: spec.template.spec.containers[0].image
           value: circleci/runner-agent:kubernetes-edge
+
+  - it: should have the default logging collector configuration
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBE_LOGGING_IMAGE
+            value: "circleci/logging-collector:3"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBE_LOGGING_SECRET
+            value: "logging-collector-token"
+  - it: should override the default logging collector configuration
+    set:
+      logging.image.registry: foo
+      logging.image.repository: bar
+      logging.image.tag: baz
+      logging.serviceAccount.secret.name: my-custom-secret
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBE_LOGGING_IMAGE
+            value: "foo/bar:baz"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: KUBE_LOGGING_SECRET
+            value: "my-custom-secret"

--- a/values.yaml
+++ b/values.yaml
@@ -227,7 +227,7 @@ logging:
   image:
     registry: ""
     repository: "circleci/logging-collector"
-    tag: edge
+    tag: 3
 
   # A service account with minimal permissions to collect the service container logs
   serviceAccount:


### PR DESCRIPTION
:gear: **Issue**

*Ticket/s*: https://circleci.atlassian.net/browse/RT-1215

:gear: **Change** 

<!-- Why the change? Please reference the ticket and AC if it exists -->
<!-- Include type of change; bug fix, new feature, breaking change, documentation, security -->
Change Type: 

AC:

:white_check_mark: **Fix**\

<!-- How did you fix the issue? -->

Use the current major release tag [3](https://hub.docker.com/layers/circleci/logging-collector/3/images/sha256-51d1d7e090c7465b20cafdae36c6681087b6aee8818a78130ecd6725f2feb30b?context=explore) instead of the rolling [edge](https://hub.docker.com/layers/circleci/logging-collector/edge/images/sha256-1d3a29bfc59f8fd3b234db0842558f1a5223b7c17ced33b35f9c55d8066f4abd?context=explore) tag.

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests! See https://github.com/circleci/server/blob/main/CONTRIBUTING.md#validating-your-work for more information. -->

Add a [couple unit tests](https://github.com/CircleCI-Public/container-runner-helm-chart/blob/a4554457c4a6a30d0097c37ccf0f5e4d616b5326/tests/deployment_test.yaml#L18-L46) to confirm that the default logging collector image tag is what we expect and also that the default settings can be overridden from the values file.

- [x] Tests for new feature and update for changes
- [x] Linting passes and/or formatting matches the standard of the repo

🗒️ **Documentation**

<!-- Did you update related documentation -->

- [x] Updated related documentation (if applicable). **N/A**
- [x] Updated Change log (if exists)
