### PR TITLE
ONPREM-554 | Support proxy env variables in container agent chart

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.0.9"
+version: "101.0.10"
 appVersion: "3"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 For deploying a CircleCI Container Agent
 
-![Version: 101.0.9](https://img.shields.io/badge/Version-101.0.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
+![Version: 101.0.10](https://img.shields.io/badge/Version-101.0.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -87,5 +87,10 @@ The command removes all the Kubernetes objects associated with the chart and del
 | logging | object | `{"image":{"registry":"","repository":"circleci/logging-collector","tag":3},"rbac":{"create":true,"role":{"name":"logging-collector","rules":[]}},"serviceAccount":{"annotations":{},"create":true,"name":"logging-collector","secret":{"name":"logging-collector-token"}}}` | Configuration values for the logging containers. These containers run alongside service containers and stream their logs to the CircleCI UI |
 | logging.serviceAccount | object | `{"annotations":{},"create":true,"name":"logging-collector","secret":{"name":"logging-collector-token"}}` | A service account with minimal permissions to collect the service container logs |
 | logging.serviceAccount.secret | object | `{"name":"logging-collector-token"}` | The secret containing the service account token |
+| proxy | object | `{"enabled":false,"http":{"auth":{"enabled":false,"password":null,"username":null},"host":"proxy.example.com","port":3128},"https":{"auth":{"enabled":false,"password":null,"username":null},"host":"proxy.example.com","port":3128},"no_proxy":[]}` | Proxy Support for Container Agent |
+| proxy.enabled | bool | `false` | If false, all proxy settings are ignored |
+| proxy.http | object | `{"auth":{"enabled":false,"password":null,"username":null},"host":"proxy.example.com","port":3128}` | Proxy for HTTP requests |
+| proxy.https | object | `{"auth":{"enabled":false,"password":null,"username":null},"host":"proxy.example.com","port":3128}` | Proxy for HTTPS requests |
+| proxy.no_proxy | list | `[]` | List of hostnames, IP CIDR blocks exempt from proxying. Loopback and intra-service traffic is never proxied. |
 | rbac | object | `{"clusterRole":{"name":"","namespace":"","rules":[]},"create":true,"role":{"name":"","namespace":"","rules":[]}}` | Kubernetes Roles Based Access Control settings |
 | serviceAccount | object | `{"annotations":{},"automountServiceAccountToken":true,"create":true,"name":""}` | Kubernetes service account settings |

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,9 @@
 
 This is the Container Agent Helm Chart changelog
 
+# 101.0.10
+- [#29](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/29) Added Proxy env support
+
 # 101.0.8
 
 - [#20](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/20) Use the current major release `3` tag instead of the rolling `edge` tag for the logging-collector image

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -92,3 +92,34 @@ true
 {{- include "container-agent.fullname" . -}}
 {{- end }}
 {{- end }}
+
+{{/* 
+proxy.env defines http proxy environment variables. It expects a list 
+with .Values.proxy first and additional no_proxy hosts as the         
+remainder of arguments 
+*/}}
+{{- define "proxy.env" }}
+{{- $proxySettings := index . 0 }}
+{{- $httpProxyUsername := index . 1 }}
+{{- $httpProxyPassword := index . 2 }}
+{{- $httpsProxyUsername := index . 3 }}
+{{- $httpsProxyPassword := index . 4 }}
+{{- $additionalNoProxyList :=  slice . 5 }}
+- name: HTTP_PROXY
+  {{- with $proxySettings.http }}
+  value: http://{{ if .auth.enabled }}{{ $httpProxyUsername }}:{{ $httpProxyPassword }}@{{ end }}{{ .host }}:{{ .port }}
+- name: http_proxy
+  value: http://{{ if .auth.enabled }}{{ $httpProxyUsername }}:{{ $httpProxyPassword }}@{{ end }}{{ .host }}:{{ .port }}
+  {{- end }}
+- name: HTTPS_PROXY
+  {{- with $proxySettings.https }}
+  value: http://{{ if .auth.enabled }}{{ $httpsProxyUsername }}:{{ $httpsProxyPassword }}@{{ end }}{{ .host }}:{{ .port }}
+- name: https_proxy
+  value: http://{{ if .auth.enabled }}{{ $httpsProxyUsername }}:{{ $httpsProxyPassword }}@{{ end }}{{ .host }}:{{ .port }}
+  {{- end }}
+- name: NO_PROXY
+  {{- $noProxy := concat $proxySettings.no_proxy $additionalNoProxyList }}
+  value: {{ join "," $noProxy | quote }}
+- name: no_proxy
+  value: {{ join "," $noProxy | quote }}
+{{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -94,6 +94,33 @@ spec:
               value: {{ .Values.logging.serviceAccount.secret.name | quote }}
             - name: KUBE_AUTODETECT_PLATFORM
               value: {{ .Values.agent.autodetectPlatform | quote }}
+            {{- if .Values.proxy.enabled }}
+            - name: PROXY__SECRETS__HTTP__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: proxy-credentials
+                  key: http-username
+                  optional: true
+            - name: PROXY__SECRETS__HTTP__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: proxy-credentials
+                  key: http-password
+                  optional: true
+            - name: PROXY__SECRETS__HTTPS__USERNAME
+              valueFrom:
+                secretKeyRef:
+                  name: proxy-credentials
+                  key: https-username
+                  optional: true
+            - name: PROXY__SECRETS__HTTPS__PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: proxy-credentials
+                  key: https-password
+                  optional: true
+            {{ include "proxy.env" (list .Values.proxy "$(PROXY__SECRETS__HTTP__USERNAME)" "$(PROXY__SECRETS__HTTP__PASSWORD)" "$(PROXY__SECRETS__HTTPS__USERNAME)" "$(PROXY__SECRETS__HTTPS__PASSWORD)" "svc.cluster.local") | indent 12 }}
+            {{- end }}         
           livenessProbe: {{ toYaml .Values.agent.livenessProbe | nindent 12 }}
           readinessProbe: {{ toYaml .Values.agent.readinessProbe | nindent 12 }}
         {{- if .Values.agent.resources }}

--- a/templates/proxy-secret.yaml
+++ b/templates/proxy-secret.yaml
@@ -1,0 +1,12 @@
+{{- if and (or .Values.proxy.http.auth.enabled .Values.proxy.https.auth.enabled) (or (not (empty .Values.proxy.http.auth.password)) (not (empty .Values.proxy.https.auth.password))) }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "container-agent.fullname" . }}-proxy-credentials
+  namespace: {{ .Release.Namespace | quote }}
+stringData:
+  http-username: {{ .Values.proxy.http.auth.username }}
+  http-password: {{ .Values.proxy.http.auth.password }}
+  https-username: {{ .Values.proxy.https.auth.username }}
+  https-password: {{ .Values.proxy.https.auth.password }}
+{{- end }}

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -44,3 +44,43 @@ tests:
           content:
             name: KUBE_LOGGING_SECRET
             value: "my-custom-secret"
+
+  - it: should have proxy configured if given
+    set:
+      proxy.enabled: true
+      proxy.http.host: proxy.test.com
+      proxy.http.port: 3128
+      proxy.https.host: proxy.test.com
+      proxy.https.port: 3128
+      proxy.no_proxy: [ "localhost", "abcd.server.com"]
+    asserts:
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTP_PROXY
+            value: http://proxy.test.com:3128
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: HTTPS_PROXY
+            value: http://proxy.test.com:3128
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: NO_PROXY
+            value: "localhost,abcd.server.com,svc.cluster.local"   
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: http_proxy
+            value: http://proxy.test.com:3128
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: https_proxy
+            value: http://proxy.test.com:3128
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: no_proxy
+            value: "localhost,abcd.server.com,svc.cluster.local"           

--- a/tests/secret_test.yaml
+++ b/tests/secret_test.yaml
@@ -1,0 +1,43 @@
+suite: test proxy secret
+templates:
+  - proxy-secret.yaml
+tests:
+  - it: should not have proxy secret if not using auth
+    set:
+      proxy.enabled: true
+      proxy.http.host: proxy.test.com
+      proxy.http.port: 3128
+      proxy.https.host: proxy.test.com
+      proxy.https.port: 3128
+      proxy.no_proxy: [ "localhost", "abcd.server.com"]
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should not have proxy secret if auth is enabled but password is not given
+    set:
+      proxy.enabled: true
+      proxy.http.host: proxy.test.com
+      proxy.http.port: 3128
+      proxy.http.auth.enabled: true
+      proxy.https.host: proxy.test.com
+      proxy.https.port: 3128
+      proxy.https.auth.enabled: true
+      proxy.no_proxy: [ "localhost", "abcd.server.com"]
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should have proxy secret if auth is enabled and password is given
+    set:
+      proxy.enabled: true
+      proxy.http.host: proxy.test.com
+      proxy.http.port: 3128
+      proxy.http.auth.enabled: true
+      proxy.http.auth.password: abcd
+      proxy.https.host: proxy.test.com
+      proxy.https.port: 3128
+      proxy.https.auth.enabled: true
+      proxy.https.auth.password: abcd
+      proxy.no_proxy: [ "localhost", "abcd.server.com"]
+    asserts:
+      - hasDocuments:
+          count: 1

--- a/values.yaml
+++ b/values.yaml
@@ -268,6 +268,5 @@ proxy:
       username:
       password:
 
-  # -- List of hostnames, IP CIDR blocks exempt from proxying. Loopback and intra-service traffic
-  # is never proxied.
+  # -- List of hostnames, IP CIDR blocks exempt from proxying. Loopback and intra-service traffic is never proxied.
   no_proxy: []

--- a/values.yaml
+++ b/values.yaml
@@ -244,3 +244,30 @@ logging:
     role:
       name: "logging-collector"
       rules: []
+
+# -- Proxy Support for Container Agent
+proxy:
+  # -- If false, all proxy settings are ignored
+  enabled: false
+
+  # -- Proxy for HTTP requests
+  http:
+    host: proxy.example.com
+    port: 3128
+    auth:
+      enabled: false
+      username: 
+      password: 
+
+  # -- Proxy for HTTPS requests
+  https:
+    host: proxy.example.com
+    port: 3128
+    auth:
+      enabled: false
+      username:
+      password:
+
+  # -- List of hostnames, IP CIDR blocks exempt from proxying. Loopback and intra-service traffic
+  # is never proxied.
+  no_proxy: []


### PR DESCRIPTION
:gear: **Issue**
If Runner container agent is deployed behind the proxy, it is not able to communicate to the world to download agent binaries 


*Ticket/s*: ONPREM-554   

:gear: **Change** 
* Added Proxy env variables in deployment
* Added Proxy Secret if using authentrication
* Added Test cases for the same

Change Type: Minor

AC:

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests! -->

- [X] Tests for new feature and update for changes
- [X] Linting passes and/or formatting matches the standard of the repo

🗒️ **Documentation**

<!-- Did you update related documentation -->

- [ ] Updated related documentation (if applicable).
- [ ] Updated Change log (if exists)
