### PR TITLE
add template to create pvc, update values.yaml

### DIFF
--- a/templates/pvc.yaml
+++ b/templates/pvc.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) -}}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "container-agent.fullname" . }}
+  annotations:
+  {{- with .Values.persistence.annotations  }}
+  {{ toYaml . | nindent 4 }}
+  {{- end }}
+    helm.sh/resource-policy: keep
+  labels:
+    app.kubernetes.io/name: {{ include "container-agent.name" . }}
+    helm.sh/chart: {{ template "container-agent.chart" . }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode | quote }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size | quote }}
+  {{- if .Values.persistence.storageClass }}
+  storageClassName: {{ .Values.persistence.storageClass | quote }}
+  {{- end }}
+{{- end -}}
+

--- a/values.yaml
+++ b/values.yaml
@@ -180,6 +180,10 @@ agent:
     #         volumeMounts:
     #           - name: xyz
     #             mountPath: /path/to/mount
+    #     volumes:
+    #       - name: xyz
+    #         persistentVolumeClaim:
+    #           claimName: container-agent
     #     securityContext:
     #       runAsNonRoot: true
     #     imagePullSecrets:
@@ -274,7 +278,6 @@ proxy:
 # -- Persistent Volume Claim
 persistence:
   enabled: false
-  name: xyz
   # existingClaim: ""
   accessMode: ReadWriteOnce
   size: 200Mi

--- a/values.yaml
+++ b/values.yaml
@@ -270,3 +270,13 @@ proxy:
 
   # -- List of hostnames, IP CIDR blocks exempt from proxying. Loopback and intra-service traffic is never proxied.
   no_proxy: []
+
+# -- Persistent Volume Claim
+persistence:
+  enabled: false
+  name: xyz
+  # existingClaim: ""
+  accessMode: ReadWriteOnce
+  size: 200Mi
+  # storageClass: ""
+  annotations: {}


### PR DESCRIPTION
Added template to create PVC for workspace persistence between jobs/pods.
The goal is to reduce excess use of network egress and storage.

My apologies for not following the pattern of PR.
