### PR TITLE
fix: check pdb under agent

### DIFF
--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -8,7 +8,7 @@ spec:
 {{- if .Values.agent.pdb.minAvailable }}
   minAvailable: {{ .Values.agent.pdb.minAvailable }}
 {{- end }}
-{{- if .Values.pdb.maxUnavailable }}
+{{- if .Values.agent.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.agent.pdb.maxUnavailable }}
 {{- end }}
   selector:


### PR DESCRIPTION
:gear: **Issue**

*Ticket/s*:   N/A

:gear: **Change** 

<!-- Why the change? Please reference the ticket and AC if it exists -->
<!-- Include type of change; bug fix, new feature, breaking change, documentation, security -->
Change Type: bug fix

:white_check_mark: **Fix**

The PDB object lives under `agent` in `values.yaml`. This check mistakenly checks the root `.Values` rather than `.Values.agent` and will cause a release with `.Values.agent.pdb.create: true` to fail with the following error:
```
failed to create chart from template: template: container-agent/templates/pdb.yaml:11:14: executing "container-agent/templates/pdb.yaml" at <.Values.pdb.maxUnavailable>: nil pointer evaluating interface {}.maxUnavailable
```
