### PR TITLE
Add finalizer on GatewayClass to ensure proper cleanup

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.0.12"
+version: "101.0.13"
 appVersion: "3"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 For deploying a CircleCI Container Agent
 
-![Version: 101.0.12](https://img.shields.io/badge/Version-101.0.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
+![Version: 101.0.13](https://img.shields.io/badge/Version-101.0.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
 
 ## Contributing
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 This is the Container Agent Helm Chart changelog
 
+# 101.0.13
+
+- [#32](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/32) Add finalizer on GatewayClass to ensure proper cleanup
+
 # 101.0.12
 
 - [#31](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/31) Fixed PDB to reference the right variable

--- a/templates/ssh.yaml
+++ b/templates/ssh.yaml
@@ -10,6 +10,8 @@ kind: GatewayClass
 metadata:
   name: {{ $name }}
   namespace: {{ $namespace }}
+  finalizers:
+    - gateway-exists-finalizer.gateway.networking.k8s.io
 spec:
   controllerName: {{ .Values.agent.ssh.controllerName }}
   {{- with .Values.agent.ssh.parametersRef }}

--- a/tests/__snapshot__/ssh_test.yaml.snap
+++ b/tests/__snapshot__/ssh_test.yaml.snap
@@ -3,6 +3,8 @@ should create Gateway and Service resources if enabled:
     apiVersion: gateway.networking.k8s.io/v1
     kind: GatewayClass
     metadata:
+      finalizers:
+        - gateway-exists-finalizer.gateway.networking.k8s.io
       name: RELEASE-NAME-container-agent-ssh
       namespace: NAMESPACE
     spec:


### PR DESCRIPTION
:gear: **Issue**

*Ticket/s*:   

:gear: **Change** 

This should ensure proper cleanup when uninstalling the Helm chart: https://gateway-api.sigs.k8s.io/reference/spec/#gateway.networking.k8s.io%2fv1alpha2.GatewayClass

<!-- Why the change? Please reference the ticket and AC if it exists -->
<!-- Include type of change; bug fix, new feature, breaking change, documentation, security -->
Change Type: 

AC:

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests! -->

- [ ] Tests for new feature and update for changes
- [ ] Linting passes and/or formatting matches the standard of the repo

🗒️ **Documentation**

<!-- Did you update related documentation -->

- [ ] Updated related documentation (if applicable).
- [ ] Updated Change log (if exists)
