### PR TITLE
Add option to specify an existing GatewayClass

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.0.14"
+version: "101.0.15"
 appVersion: "3"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 For deploying a CircleCI Container Agent
 
-![Version: 101.0.14](https://img.shields.io/badge/Version-101.0.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
+![Version: 101.0.15](https://img.shields.io/badge/Version-101.0.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
 
 ## Contributing
 
@@ -84,8 +84,9 @@ The command removes all the Kubernetes objects associated with the chart and del
 | agent.runnerAPI | string | `"https://runner.circleci.com"` | CircleCI Runner API URL |
 | agent.ssh.controllerName | string | `"gateway.envoyproxy.io/gatewayclass-controller"` | The name of the infrastructure provider for the SSH rerun Gateway (see: https://gateway-api.sigs.k8s.io/implementations/). SSH reruns depend on the TCPRoute resource, so only implementations that support it are compatible at this time. Please consult the documentation for your preferred Gateway implementation for guidance on setting it up in your cluster. The Envoy Gateway has been successfully tested for SSH reruns (see: https://gateway.envoyproxy.io/latest/user/tcp-routing/). |
 | agent.ssh.enabled | bool | `false` | Controls whether to enable SSH reruns (see: https://circleci.com/docs/ssh-access-jobs/). Note that enabling SSH reruns will install additional resources to your cluster. Notably, SSH reruns requires the Kubernetes Gateway API (see: https://gateway-api.sigs.k8s.io/). |
+| agent.ssh.existingGatewayClassName | string | `""` | Alternatively, you can provide an existing GatewayClass name instead of creating a new one. The GatewayClass resource is a cluster-scoped resource defined by the infrastructure provider, so you may want to manage this resource externally. Note: Configuration specific to SSH reruns is defined in the namespace-scoped Gateway resource. For more information, see: https://gateway-api.sigs.k8s.io/api-types/gatewayclass/#gatewayclass |
 | agent.ssh.numPorts | int | `20` |  |
-| agent.ssh.parametersRef | object | `{}` |  |
+| agent.ssh.parametersRef | object | `{}` | Specify controller-specific configuration for the Gateway. For more information, see: https://gateway-api.sigs.k8s.io/api-types/gatewayclass/#gatewayclass-parameters |
 | agent.ssh.startPort | int | `54782` | Specify the port range that is approved for SSH connections. Note that the number of concurrent jobs rerun with SSH is limited by the number of ports in this range. |
 | agent.terminationGracePeriodSeconds | int | `18300` | Tasks are drained during the termination grace period, so this should be sufficiently long relative to the maximum run time to ensure graceful shutdown |
 | agent.tolerations | list | `[]` | Node tolerations for agent scheduling to nodes with taints Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |

--- a/changelog.md
+++ b/changelog.md
@@ -2,13 +2,17 @@
 
 This is the Container Agent Helm Chart changelog
 
+# 101.0.15
+
+- [#34](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/34) [PRERELEASE] Add an option to specify an existing GatewayClass for SSH reruns
+
 # 101.0.14
 
-- [#34](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/34) Support the namespace field in ParametersReference for the SSH reruns GatewayClass
+- [#35](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/35) [PRERELEASE] Support the namespace field in ParametersReference for the SSH reruns GatewayClass
 
 # 101.0.13
 
-- [#33](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/33) Add finalizer on GatewayClass to ensure proper cleanup
+- [#33](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/33) [PRERELEASE] Add finalizer on GatewayClass to ensure proper cleanup
 
 # 101.0.12
 

--- a/templates/ssh.yaml
+++ b/templates/ssh.yaml
@@ -5,6 +5,7 @@
 {{- $namespace := .Release.Namespace | quote }}
 {{- $name := printf "%s-ssh" (include "container-agent.fullname" .) }}
 
+{{- if not .Values.agent.ssh.existingGatewayClassName -}}
 apiVersion: gateway.networking.k8s.io/v1
 kind: GatewayClass
 metadata:
@@ -23,6 +24,7 @@ spec:
     namespace: {{ .namespace }}
     {{- end }}
   {{- end }}
+{{- end }}
 
 ---
 apiVersion: gateway.networking.k8s.io/v1
@@ -31,7 +33,7 @@ metadata:
   name: {{ $name }}
   namespace: {{ $namespace }}
 spec:
-  gatewayClassName: {{ $name }}
+  gatewayClassName: {{ default $name .Values.agent.ssh.existingGatewayClassName }}
   listeners:
     {{- range $i, $port := $ports }}
     - name: ssh-{{ $port }}

--- a/tests/ssh_test.yaml
+++ b/tests/ssh_test.yaml
@@ -90,3 +90,17 @@ tests:
           content:
             name: KUBE_SSH_SERVICE_NAME
             value: "RELEASE-NAME-container-agent-ssh"
+
+  - it: should not create a GatewayClass if an existing GatewayClass name is provided
+    template: templates/ssh.yaml
+    set:
+      agent.ssh.enabled: true
+      agent.ssh.existingGatewayClassName: "gwc"
+    asserts:
+      - notMatchRegex:
+          path: kind
+          pattern: GatewayClass
+      - equal:
+          path: spec.gatewayClassName
+          value: "gwc"
+        documentIndex: 0

--- a/values.yaml
+++ b/values.yaml
@@ -213,7 +213,14 @@ agent:
     # Please consult the documentation for your preferred Gateway implementation for guidance on setting it up in your cluster.
     # The Envoy Gateway has been successfully tested for SSH reruns (see: https://gateway.envoyproxy.io/latest/user/tcp-routing/).
     controllerName: "gateway.envoyproxy.io/gatewayclass-controller"
+    # -- Specify controller-specific configuration for the Gateway.
+    # For more information, see: https://gateway-api.sigs.k8s.io/api-types/gatewayclass/#gatewayclass-parameters
     parametersRef: {}
+    # -- Alternatively, you can provide an existing GatewayClass name instead of creating a new one. The GatewayClass resource is a
+    # cluster-scoped resource defined by the infrastructure provider, so you may want to manage this resource externally.
+    # Note: Configuration specific to SSH reruns is defined in the namespace-scoped Gateway resource.
+    # For more information, see: https://gateway-api.sigs.k8s.io/api-types/gatewayclass/#gatewayclass
+    existingGatewayClassName: ""
 
     # -- Specify the port range that is approved for SSH connections.
     # Note that the number of concurrent jobs rerun with SSH is limited by the number of ports in this range.


### PR DESCRIPTION
:gear: **Issue**

*Ticket/s*:   

:gear: **Change** 

A GatewayClass is a cluster-scoped resource defined by the infrastructure provider. For permission reasons, it may make sense to externalize this. Or perhaps to share a GatewayClass among multiple container-agent instances. 

<!-- Why the change? Please reference the ticket and AC if it exists -->
<!-- Include type of change; bug fix, new feature, breaking change, documentation, security -->
Change Type: 

AC:

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests! -->

- [ ] Tests for new feature and update for changes
- [ ] Linting passes and/or formatting matches the standard of the repo

🗒️ **Documentation**

<!-- Did you update related documentation -->

- [ ] Updated related documentation (if applicable).
- [ ] Updated Change log (if exists)
