### PR TITLE
Add option to set arbitrary environment variables for container-agent [ONPREM-616]

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.0.15"
+version: "101.0.16"
 appVersion: "3"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 For deploying a CircleCI Container Agent
 
-![Version: 101.0.15](https://img.shields.io/badge/Version-101.0.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
+![Version: 101.0.16](https://img.shields.io/badge/Version-101.0.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
 
 ## Contributing
 
@@ -56,6 +56,7 @@ The command removes all the Kubernetes objects associated with the chart and del
 | agent.constraintChecker.threshold | int | `3` | Number of failed checks before disabling task claim |
 | agent.containerSecurityContext | object | `{}` | Security Context policies for agent containers |
 | agent.customSecret | string | `""` | Name of the user provided secret containing resource class tokens. You can mix tokens from this secret and in the secret created from tokens specified in the resourceClasses section below Ref: https://circleci.com/docs/container-runner/#custom-secret  The tokens should be specified as secret key-value pairs of the form ResourceClass: Token The resource class name needs to match the names configured below exactly to match tokens to the correct configuration As Kubernetes does not allow / in secret keys, a period (.) should be substituted instead |
+| agent.environment | object | `{}` | A dictionary of key-value pairs to set as environment variables in the container-agent app container. Note that this does not set environment variables in a task, which can be done via `agent.resourceClasses` or in CircleCI: https://circleci.com/docs/set-environment-variable. |
 | agent.forceUpdate | bool | `false` | Force a rolling update of the agent deployment |
 | agent.image | object | `{"digest":"","pullPolicy":"Always","registry":"","repository":"circleci/runner-agent","tag":"kubernetes-3"}` | Agent image settings. NOTE: Setting an image digest will take precedence over the image tag |
 | agent.kubeGCEnabled | bool | `true` | Enable garbage collection of dangling Kubernetes objects managed by container agent |

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 This is the Container Agent Helm Chart changelog
 
+# 101.0.16
+
+- [#36](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/36) Add field to set arbitrary environment variables for container-agent
+
 # 101.0.15
 
 - [#34](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/34) [PRERELEASE] Add an option to specify an existing GatewayClass for SSH reruns

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -105,6 +105,11 @@ spec:
               value: {{ $sshName }}
             {{- end }} # if .Values.agent.ssh.enabled
 
+            {{- range $key, $value := .Values.agent.environment }}
+            - name: "{{ $key }}"
+              value: "{{ $value }}"
+            {{- end }}
+
             {{- if .Values.proxy.enabled }}
             - name: PROXY__SECRETS__HTTP__USERNAME
               valueFrom:

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -45,6 +45,27 @@ tests:
             name: KUBE_LOGGING_SECRET
             value: "my-custom-secret"
 
+  - it: should set environment variables provided in agent.environment
+    template: templates/deployment.yaml
+    set:
+      agent.environment.FOO: BAR
+      agent.environment.BAZ: QUX
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: Deployment
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "FOO"
+            value: "BAR"
+      - contains:
+          path: spec.template.spec.containers[0].env
+          content:
+            name: "BAZ"
+            value: "QUX"
+
   - it: should have proxy configured if given
     set:
       proxy.enabled: true
@@ -83,4 +104,4 @@ tests:
           path: spec.template.spec.containers[0].env
           content:
             name: no_proxy
-            value: "localhost,abcd.server.com,svc.cluster.local"           
+            value: "localhost,abcd.server.com,svc.cluster.local"

--- a/values.yaml
+++ b/values.yaml
@@ -33,6 +33,11 @@ agent:
   # -- Force a rolling update of the agent deployment
   forceUpdate: false
 
+  # -- A dictionary of key-value pairs to set as environment variables in the container-agent app container.
+  # Note that this does not set environment variables in a task, which can be done via `agent.resourceClasses` or
+  # in CircleCI: https://circleci.com/docs/set-environment-variable.
+  environment: {}
+
   # -- Liveness and readiness probe values
   # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes
   livenessProbe:


### PR DESCRIPTION
:gear: **Issue**

*Ticket/s*: https://circleci.atlassian.net/browse/ONPREM-616

:gear: **Change** 

Add option to set arbitrary environment variables for container-agent. This'll allow us to test out new feature flags and other new configuration options on edge more easily.

<!-- Why the change? Please reference the ticket and AC if it exists -->
<!-- Include type of change; bug fix, new feature, breaking change, documentation, security -->
Change Type: 

AC:

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests! -->

- [x] Tests for new feature and update for changes
- [x] Linting passes and/or formatting matches the standard of the repo

🗒️ **Documentation**

<!-- Did you update related documentation -->

- [x] Updated related documentation (if applicable).
- [x] Updated Change log (if exists)
