### PR TITLE
fix clusterrole indentation when adding rules

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.0.18"
+version: "101.0.19"
 appVersion: "3"

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,10 @@
 
 This is the Container Agent Helm Chart changelog
 
+# 101.0.19
+
+- [#39](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/39) fix clusterrole indentation when adding rules #39
+
 # 101.0.18
 
 - [#38](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/38) Add option to set the garbage collection (GC) period to tune how quickly failed Pods are removed.

--- a/templates/clusterrole.yaml
+++ b/templates/clusterrole.yaml
@@ -16,7 +16,7 @@ rules:
     resources: ["nodes"]
     verbs: ["get", "list"]
 {{- if $clusterRole.rules }}
-  {{- toYaml $clusterRole.rules | indent 2 }}
+  {{- toYaml $clusterRole.rules | nindent 2 }}
 {{- end }} # if $clusterRole.rules
 ---
 apiVersion: rbac.authorization.k8s.io/v1


### PR DESCRIPTION
:gear: **Issue**

*Ticket/s*:   None

:gear: **Change** 

Use `nindent` instead of `indent` to allow creation of new `clusterRole.rules`.

Change Type: 

AC:

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests! -->

- [ x ] Tests for new feature and update for changes
- [ x ] Linting passes and/or formatting matches the standard of the repo

🗒️ **Documentation**

<!-- Did you update related documentation -->

- [ x ] Updated related documentation (if applicable).
- [ x ] Updated Change log (if exists)
