### PR TITLE
Fixed adding additional RBAC rules.

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,5 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.0.20"
+version: "101.0.21"
 appVersion: "3"

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,8 @@
 # Container Agent Helm Chart Changelog
 
 This is the Container Agent Helm Chart changelog
+# 101.0.21
+- [#42](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/42) Fix formatting bug when adding role and logging role rules
 
 # 101.0.20
 

--- a/templates/role.yaml
+++ b/templates/role.yaml
@@ -27,7 +27,7 @@ rules:
   {{- end }} # if .Values.agent.ssh.enabled
 
 {{- if $role.rules }}
-  {{- toYaml $role.rules | indent 2 }}
+  {{- toYaml $role.rules | nindent 2 }}
 {{- end }} # if $role.rules
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -63,7 +63,7 @@ rules:
     resources: ["pods/log"]
     verbs: ["get"]
 {{- if $loggingRole.rules }}
-  {{- toYaml $loggingRole.rules | indent 2 }}
+  {{- toYaml $loggingRole.rules | nindent 2 }}
 {{- end }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/tests/roles_test.yaml
+++ b/tests/roles_test.yaml
@@ -1,0 +1,45 @@
+suite: test roles
+tests:
+  - it: should format additional roles correctly
+    template: templates/role.yaml
+    set:
+      rbac.role.create: true
+      rbac.role.rules:
+        - apiGroups: [""]
+          resources: ["configmaps"]
+          verbs: ["get"]
+      logging.rbc.create: true
+      logging.rbac.role.rules:
+        - apiGroups: [""]
+          resources: ["configmaps"]
+          verbs: ["get"]
+    asserts:
+      - equal:
+          path: rules
+          value:
+            - apiGroups: [""]
+              resources: ["pods", "pods/exec", "pods/log"]
+              verbs: ["get", "watch", "list", "create", "delete"]
+            - apiGroups: [""]
+              resources: ["secrets"]
+              verbs: ["get", "list", "create", "delete"]
+            - apiGroups: ["", "events.k8s.io/v1"]
+              resources: ["events"]
+              verbs: ["watch"]
+            - apiGroups: [""]
+              resources: ["configmaps"]
+              verbs: ["get"]
+        documentIndex: 0
+      - equal:
+          path: rules
+          value:
+            - apiGroups: [""]
+              resources: ["pods"]
+              verbs: ["watch"]
+            - apiGroups: [""]
+              resources: ["pods/log"]
+              verbs: ["get"]
+            - apiGroups: [""]
+              resources: ["configmaps"]
+              verbs: ["get"]
+        documentIndex: 2


### PR DESCRIPTION
:gear: **Issue**

When adding additional role rules or logging role rules, the manifest it renders ends up missing a newline and always returning an error.

`Error: YAML parse error on container-agent/templates/role.yaml: error converting YAML to JSON: yaml: line 15: did not find expected key
helm.go:84: [debug] error converting YAML to JSON: yaml: line 15: did not find expected key`

:gear: **Change** 

Altered the toYaml section for the extra rules to use 'nindent' instead of 'indent' to introduce a newline in order to fix the formatting. 

AC:

:white_check_mark: **Fix**

When providing additional rules, the manifest now renders as valid YAML.

:question: **Tests**

Ran helm template command locally and before the change it rendered and errored:
```
rules:
  - apiGroups: [""]
    resources: ["pods", "pods/exec", "pods/log"]
    verbs: ["get", "watch", "list", "create", "delete"]
  - apiGroups: [""]
    resources: ["secrets"]
    verbs: ["get", "list", "create", "delete"]
  - apiGroups: ["", "events.k8s.io/v1"]
    resources: ["events"]
    verbs: ["watch"] # if .Values.agent.ssh.enabled  - apiGroups:
    - ""
    resources:
    - configmaps
    verbs:
    - get
    - list
    - create
    - update
    - delete # if $role.rules
```
    
 After the change it rendered and ran correctly:
```
 rules:
  - apiGroups: [""]
    resources: ["pods", "pods/exec", "pods/log"]
    verbs: ["get", "watch", "list", "create", "delete"]
  - apiGroups: [""]
    resources: ["secrets"]
    verbs: ["get", "list", "create", "delete"]
  - apiGroups: ["", "events.k8s.io/v1"]
    resources: ["events"]
    verbs: ["watch"] # if .Values.agent.ssh.enabled  
  - apiGroups:
    - ""
    resources:
    - configmaps
    verbs:
    - get
    - list
    - create
    - update
    - delete # if $role.rules
```

🗒️ **Documentation**

N/A -- Just a bug fix
