### PR TITLE
Onprem 262/set kubeversion

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,5 +4,6 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.0.22"
+version: "101.0.23"
 appVersion: "3"
+kubeVersion: ">= 1.25"

--- a/README.md
+++ b/README.md
@@ -2,13 +2,17 @@
 
 For deploying a CircleCI Container Agent
 
-![Version: 101.0.22](https://img.shields.io/badge/Version-101.0.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
+![Version: 101.0.23](https://img.shields.io/badge/Version-101.0.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
 
 ## Contributing
 
 ### Prerequisites
 
-- Kubernetes 1.12+
+## Requirements
+
+Kubernetes: `>= 1.25`
+
+- Kubernetes 1.25+
 - Helm 3.x
 
 ### Installing the Chart

--- a/templates/README.md.gotmpl
+++ b/templates/README.md.gotmpl
@@ -8,7 +8,7 @@
 ### Prerequisites
 
 {{ template "chart.requirementsSection" . }}
-- Kubernetes 1.12+
+- Kubernetes 1.25+
 - Helm 3.x
 
 ### Installing the Chart


### PR DESCRIPTION
:gear: **[ONPREM-262](https://circleci.atlassian.net/browse/ONPREM-262)**

*Ticket/s*:   

:gear: **Change** 

sets minimum kubeversion to 1.25

<!-- Why the change? Please reference the ticket and AC if it exists -->
<!-- Include type of change; bug fix, new feature, breaking change, documentation, security -->
Change Type: 

AC:

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests! -->

- [ ] Tests for new feature and update for changes
- [ ] Linting passes and/or formatting matches the standard of the repo

🗒️ **Documentation**

<!-- Did you update related documentation -->

- [ ] Updated related documentation (if applicable).
- [ ] Updated Change log (if exists)


[ONPREM-262]: https://circleci.atlassian.net/browse/ONPREM-262?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ