### PR TITLE
[ONPREM-1075] Use correct env var for task volume and update changelog with unreleased changes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,6 @@ jobs:
     resource_class: medium
     steps:
       - checkout
-      - run: ./do check-version-bump
       - run: helm lint
       - run: helm template --debug .
       - run: ./do unit-tests
@@ -82,6 +81,7 @@ jobs:
       - checkout
       - attach_workspace:
           at: .
+      - run: ./do check-version-bump
       - run: gem install --no-document package_cloud
       - run: ./do publish
       - notify_slack:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,6 +4,6 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.0.24"
+version: "101.0.22"
 appVersion: "3"
 kubeVersion: ">= 1.25"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 For deploying a CircleCI Container Agent
 
-![Version: 101.0.24](https://img.shields.io/badge/Version-101.0.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
+![Version: 101.0.22](https://img.shields.io/badge/Version-101.0.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
 
 ## Contributing
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,13 @@
 # Container Agent Helm Chart Changelog
 
+# Edge
+
+# 101.0.22
+
+- [#47](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/47) [EXPERIMENTAL] Set correct env var for shared task volume
+- [#44](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/44) [EXPERIMENTAL] Add toggle for shared task volume
+- [#45](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/45) Set minimum kubeVersion in Chart.yaml
+
 This is the Container Agent Helm Chart changelog
 # 101.0.21
 - [#42](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/42) Fix formatting bug when adding role and logging role rules

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -99,7 +99,7 @@ spec:
             - name: KUBE_AUTODETECT_PLATFORM
               value: {{ .Values.agent.autodetectPlatform | quote }}
             {{- if .Values.agent.taskVolume.enabled }}
-            - name: KUBE_SHARED_TASK_AGENT_VOLUME
+            - name: KUBE_SHARED_TASK_VOLUME
               value: {{ include "container-agent.fullname" . }}
             {{- end }}
             {{- with .Values.agent }}

--- a/tests/deployment_test.yaml
+++ b/tests/deployment_test.yaml
@@ -146,7 +146,7 @@ tests:
       - contains:
           path: spec.template.spec.containers[0].env
           content:
-            name: KUBE_SHARED_TASK_AGENT_VOLUME
+            name: KUBE_SHARED_TASK_VOLUME
             value: RELEASE-NAME-container-agent
       - equal:
           path: spec.template.spec.securityContext


### PR DESCRIPTION
:gear: **Issue**

*Ticket/s*:   https://circleci.atlassian.net/browse/ONPREM-1075

:gear: **Change** 

<!-- Why the change? Please reference the ticket and AC if it exists -->
<!-- Include type of change; bug fix, new feature, breaking change, documentation, security -->
Change Type: Bug fix/Maintainance

:white_check_mark: **Fix**

Set the right env var for the shared task volume

Also reset the chart version to 101.0.22 (as the last released patch was 21)
Only check the version bump in the publish workflow (We now don't release every commit)

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests! -->

- [x] Tests for new feature and update for changes
- [x] Linting passes and/or formatting matches the standard of the repo

🗒️ **Documentation**

<!-- Did you update related documentation -->

- [ ] Updated related documentation (if applicable).
- [x] Updated Change log 
