### PR TITLE
[ONPREM-262] Add -0 to kubeversion check

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,6 +4,6 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.0.22"
+version: "101.0.21"
 appVersion: "3"
-kubeVersion: ">= 1.25"
+kubeVersion: ">= 1.25-0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 For deploying a CircleCI Container Agent
 
-![Version: 101.0.22](https://img.shields.io/badge/Version-101.0.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
+![Version: 101.0.21](https://img.shields.io/badge/Version-101.0.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3](https://img.shields.io/badge/AppVersion-3-informational?style=flat-square)
 
 ## Contributing
 
@@ -10,7 +10,7 @@ For deploying a CircleCI Container Agent
 
 ## Requirements
 
-Kubernetes: `>= 1.25`
+Kubernetes: `>= 1.25-0`
 
 Helm: 3.x
 


### PR DESCRIPTION
:gear: **Issue**

*Ticket/s*:   ONPREM-262

:gear: **Change** 

<!-- Why the change? Please reference the ticket and AC if it exists -->
<!-- Include type of change; bug fix, new feature, breaking change, documentation, security -->
Change Type: Bug fix

Helm uses a semVer package to validate the kubeVersion constraint which will skip prerelease versions if the constraint version does not include a prerelease part. Unfortunately the cloud K8s distributions use the preRelease tag to include cloud specific version data so we need to include those versions otherwise the constraint will fail for most distributions