### PR TITLE
Only trigger the Kubernetes smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,7 @@ workflows:
       - package
       - smoke-tests:
           context: runner-deploy
+          requires: [ validate ]
 
       - approve-publish:
           type: approval
@@ -55,7 +56,10 @@ jobs:
           name: Run the smoke tests
           command: |
             cd ./runner-init
-            SMOKE_TESTS_KUBERNETES_HELM_CHART_BRANCH="${CIRCLE_BRANCH}" ./do smoke-tests
+
+            SMOKE_TESTS_MACHINE_SKIP="true" \
+            SMOKE_TESTS_KUBERNETES_HELM_CHART_BRANCH="${CIRCLE_BRANCH}" \
+            ./do smoke-tests
       - notify_failing_main
 
   check_readme:


### PR DESCRIPTION
The machine runner tests aren't relevant to the Helm chart

:gear: **Issue**

*Ticket/s*:   

:gear: **Change** 

<!-- Why the change? Please reference the ticket and AC if it exists -->
<!-- Include type of change; bug fix, new feature, breaking change, documentation, security -->
Change Type: 

AC:

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests! -->

- [ ] Tests for new feature and update for changes
- [ ] Linting passes and/or formatting matches the standard of the repo

🗒️ **Documentation**

<!-- Did you update related documentation -->

- [ ] Updated related documentation (if applicable).
- [ ] Updated Change log (if exists)
