### PR TITLE
Only render configmap if resourceClasses are set

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The command removes all the Kubernetes objects associated with the chart and del
 | agent.readinessProbe.successThreshold | int | `1` |  |
 | agent.readinessProbe.timeoutSeconds | int | `1` |  |
 | agent.replicaCount | int | `1` |  |
-| agent.resourceClasses | object | `{}` | Resource class settings. The tokens specified here will be used to claim tasks & the tasks will be launched with the configured configs Ref: https://circleci.com/docs/container-runner/#resource-class-configuration-custom-pod |
+| agent.resourceClasses | object | `{}` | Resource class settings. The tokens specified here will be used to claim tasks & the tasks will be launched with the configured configs If you leave this unset you must provide your own configmap named {{ include "container-agent.fullname" . }} Ref: https://circleci.com/docs/container-runner/#resource-class-configuration-custom-pod |
 | agent.resources | object | `{}` | Agent pod resource configuration Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | agent.runnerAPI | string | `"https://runner.circleci.com"` | CircleCI Runner API URL |
 | agent.serviceContainers | object | `{}` | Configuration for service containers. This allows different a different container spec to be passed to your job's service containers. TODO: Full docs link |

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.agent.resourceClasses }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -18,3 +19,4 @@ data:
     serviceContainers:
       {{- toYaml .Values.agent.serviceContainers | nindent 6 }}
     {{- end }}
+{{- end }}

--- a/tests/configmap_test.yaml
+++ b/tests/configmap_test.yaml
@@ -54,3 +54,9 @@ tests:
                     resources:
                       limits:
                         cpu: 500m
+  - it: should be empty when no resourceClasses are set
+    set:
+      agent.resourceClasses: {}
+    asserts:
+     - hasDocuments:
+        count: 0

--- a/values.yaml
+++ b/values.yaml
@@ -191,6 +191,7 @@ agent:
 
   # -- Resource class settings. The tokens specified here will be used to claim tasks & the tasks
   # will be launched with the configured configs
+  # If you leave this unset you must provide your own configmap named {{ include "container-agent.fullname" . }}
   # Ref: https://circleci.com/docs/container-runner/#resource-class-configuration-custom-pod
   resourceClasses: {}
     # circleci-runner/resourceClass:


### PR DESCRIPTION
:gear: [**Issue**](https://github.com/CircleCI-Public/container-runner-helm-chart/issues/80)

This allows one to render your own configmap using the helm template toolchain. Otherwise you are limited to using the values.yaml file which doesn't have templating capabilities.

Change Type: QOL feature? 

AC:

:white_check_mark: **Fix**

Added an if statement around the entire configmap

:question: **Tests**

- [x] Tests for new feature and update for changes
- [x] Linting passes and/or formatting matches the standard of the repo
Note: 1 pre-existing warning was present

🗒️ **Documentation**

- [x] Updated related documentation (if applicable).
- [ ] Updated Change log (if exists)
