### PR TITLE
fix: pdb template

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,9 @@ The command removes all the Kubernetes objects associated with the chart and del
 | agent.maxRunTime | string | `"5h"` |  |
 | agent.name | string | `""` | A (preferably) unique name assigned to this particular container-agent instance. This name will appear in your runners inventory page in the CircleCI UI. If left unspecified, the name will default to the name of the deployment. |
 | agent.nodeSelector | object | `{}` | Node labels for agent pod assignment Ref: https://kubernetes.io/docs/user-guide/node-selection/ |
-| agent.pdb | object | `{"create":false,"maxUnavailable":1,"minAvailable":1}` | Pod disruption budget settings |
+| agent.pdb.create | string | `false` | Create a pod disruption budget |
+| agent.pdb.minAvailable | string | `1` | Minimum available pods set in PodDisruptionBudget. Define either 'minAvailable' or 'maxUnavailable', never both. |
+| agent.pdb.maxUnavailable | string | `null` | Maximum unavailable pods set in PodDisruptionBudget. If set, 'minAvailable' is ignored. |
 | agent.podAnnotations | object | `{}` | Annotations to be added to agent pods |
 | agent.podSecurityContext | object | `{}` | Security Context policies for agent pods |
 | agent.pullSecrets | list | `[]` |  |

--- a/templates/pdb.yaml
+++ b/templates/pdb.yaml
@@ -4,12 +4,11 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "container-agent.fullname" . }}
 spec:
-{{- if .Values.agent.pdb.minAvailable }}
+  {{- if and .Values.agent.pdb.minAvailable (not (hasKey .Values.agent.pdb "maxUnavailable")) }}
   minAvailable: {{ .Values.agent.pdb.minAvailable }}
-{{- end }}
-{{- if .Values.agent.pdb.maxUnavailable }}
+  {{- else if .Values.agent.pdb.maxUnavailable }}
   maxUnavailable: {{ .Values.agent.pdb.maxUnavailable }}
-{{- end }}
+  {{- end }}
   selector:
     matchLabels:
       {{- toYaml .Values.agent.matchLabels | nindent 6 }}

--- a/tests/pdb_test.yaml
+++ b/tests/pdb_test.yaml
@@ -1,0 +1,69 @@
+suite: test pod disruption budget
+templates:
+  - pdb.yaml
+tests:
+  - it: should not create a pod disruption budget by default
+    asserts:
+      - notExists:
+          kind: PodDisruptionBudget
+
+  - it: should create a pod disruption budget when enabled
+    set:
+      agent:
+        pdb:
+          create: true
+    asserts:
+      - exists:
+          kind: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - equal:
+          path: spec.selector.matchLabels.app
+          value: container-agent
+
+  - it: should set minAvailable when specified
+    set:
+      agent:
+        pdb:
+          create: true
+          minAvailable: 3
+    asserts:
+      - exists:
+          kind: PodDisruptionBudget
+      - equal:
+          path: spec.minAvailable
+          value: 3
+      - notExists:
+          path: spec.maxUnavailable
+
+  - it: should set maxUnavailable when specified
+    set:
+      agent:
+        pdb:
+          create: true
+          maxUnavailable: 2
+    asserts:
+      - exists:
+          kind: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: 2
+      - notExists:
+          path: spec.minAvailable
+
+  - it: should prefer maxUnavailable if both minAvailable and maxUnavailable are set
+    set:
+      agent:
+        pdb:
+          create: true
+          minAvailable: 2
+          maxUnavailable: 3
+    asserts:
+      - exists:
+          kind: PodDisruptionBudget
+      - equal:
+          path: spec.maxUnavailable
+          value: 3
+      - notExists:
+          path: spec.minAvailable

--- a/values.yaml
+++ b/values.yaml
@@ -135,10 +135,14 @@ agent:
   #     topologyKey: "kubernetes.io/hostname"
 
   # -- Pod disruption budget settings
+  # Ref: https://kubernetes.io/docs/tasks/run-application/configure-pdb/
   pdb:
     create: false
+    # -- Minimum available pods set in PodDisruptionBudget.
+    # Define either 'minAvailable' or 'maxUnavailable', never both.
     minAvailable: 1
-    maxUnavailable: 1
+    # -- Maximum unavailable pods set in PodDisruptionBudget. If set, 'minAvailable' is ignored.
+    # maxUnavailable: 1
 
   # -- CircleCI Runner API URL
   runnerAPI: "https://runner.circleci.com"


### PR DESCRIPTION
:gear: **Issue**
Fixes the issue of the pod disruption budget defining both `minAvailable` and `maxUnavailable`.

*Ticket/s*:   

:gear: **Change** 

<!-- Why the change? Please reference the ticket and AC if it exists -->
<!-- Include type of change; bug fix, new feature, breaking change, documentation, security -->
Change Type: Fix

AC:

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->
Updated the pdb template to account for if both options are set go with the `maxUnavailable` field.  By default just the `minAvailable` field is set (which is being done by commenting out the `maxUnavailable` field in `values.yaml`), and can still be updated via values.

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests! -->
Added new file `pdb_test.yaml` for testing out the rendered pdb resource

- [x] Tests for new feature and update for changes
- [x] Linting passes and/or formatting matches the standard of the repo

🗒️ **Documentation**

<!-- Did you update related documentation -->

- [x] Updated related documentation (if applicable).
- [ ] Updated Change log (if exists)
