### PR TITLE
[ONPREM-2386] Add agent.existingConfigMap to allow bringing your own ConfigMap 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ The command removes all the Kubernetes objects associated with the chart and del
 | agent.readinessProbe.successThreshold | int | `1` |  |
 | agent.readinessProbe.timeoutSeconds | int | `1` |  |
 | agent.replicaCount | int | `1` |  |
-| agent.resourceClasses | object | `{}` | Resource class settings. The tokens specified here will be used to claim tasks & the tasks will be launched with the configured configs Ref: https://circleci.com/docs/container-runner/#resource-class-configuration-custom-pod |
+| agent.resourceClasses | object | `{}` | Resource class settings. The tokens specified here will be used to claim tasks & the tasks will be launched with the configured configs If you leave this unset you must provide your own configmap named {{ include "container-agent.fullname" . }} Ref: https://circleci.com/docs/container-runner/#resource-class-configuration-custom-pod |
 | agent.resources | object | `{}` | Agent pod resource configuration Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | agent.runnerAPI | string | `"https://runner.circleci.com"` | CircleCI Runner API URL |
 | agent.serviceContainers | object | `{}` | Configuration for service containers. This allows different a different container spec to be passed to your job's service containers. TODO: Full docs link |

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ The command removes all the Kubernetes objects associated with the chart and del
 | agent.containerSecurityContext | object | `{}` | Security Context policies for agent containers |
 | agent.customSecret | string | `""` | Name of the user provided secret containing resource class tokens. You can mix tokens from this secret and in the secret created from tokens specified in the resourceClasses section below Ref: https://circleci.com/docs/container-runner/#custom-secret  The tokens should be specified as secret key-value pairs of the form ResourceClass: Token The resource class name needs to match the names configured below exactly to match tokens to the correct configuration As Kubernetes does not allow / in secret keys, a period (.) should be substituted instead |
 | agent.environment | object | `{}` | A dictionary of key-value pairs to set as environment variables in the container-agent app container. Note that this does not set environment variables in a task, which can be done via `agent.resourceClasses` or [in CircleCI](https://circleci.com/docs/set-environment-variable). |
+| agent.existingConfigMap | string | `""` | Option to use an existing ConfigMap instead of creating one from resourceClasses. If set, no ConfigMap will be rendered by this chart. |
 | agent.forceUpdate | bool | `false` | Force a rolling update of the agent deployment |
 | agent.gc.enabled | bool | `true` | Enable garbage collection (GC) of Kubernetes objects such as Pods or Secrets left over from CircleCI tasks. Dangling objects may occur if container runner is forcefully deleted, causing the task state-tracking to be lost. GC will only remove objects labelled with `app.kubernetes.io/managed-by=circleci-container-agent`. |
 | agent.gc.interval | string | `"3m"` | Frequency of GC runs. Adjust this to balance minimal lingering K8s resources vs. system load. Infrequent runs may reduce the load but could result in excess K8s resources, while frequent runs help minimize resources but could increase system load. |
@@ -90,7 +91,7 @@ The command removes all the Kubernetes objects associated with the chart and del
 | agent.readinessProbe.successThreshold | int | `1` |  |
 | agent.readinessProbe.timeoutSeconds | int | `1` |  |
 | agent.replicaCount | int | `1` |  |
-| agent.resourceClasses | object | `{}` | Resource class settings. The tokens specified here will be used to claim tasks & the tasks will be launched with the configured configs If you leave this unset you must provide your own configmap named {{ include "container-agent.fullname" . }} Ref: https://circleci.com/docs/container-runner/#resource-class-configuration-custom-pod |
+| agent.resourceClasses | object | `{}` | Resource class settings. The tokens specified here will be used to claim tasks & the tasks will be launched with the configured configs Ref: https://circleci.com/docs/container-runner/#resource-class-configuration-custom-pod |
 | agent.resources | object | `{}` | Agent pod resource configuration Ref: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ |
 | agent.runnerAPI | string | `"https://runner.circleci.com"` | CircleCI Runner API URL |
 | agent.serviceContainers | object | `{}` | Configuration for service containers. This allows different a different container spec to be passed to your job's service containers. TODO: Full docs link |

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,8 @@
 
 # Edge
 
+[#81](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/81) Don't render ConfigMap if `agent.resourceClasses` is unset. This allows you to template your own configmap.
+
 # 101.1.7
 - Upgraded the container-agent app image to version `3.1.8`
 - [#98](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/98) Fixed ClusterRole name formatting without quotes.

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,7 @@
 
 # Edge
 
-[#81](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/81) Don't render ConfigMap if `agent.resourceClasses` is unset. This allows you to template your own configmap.
+[#81](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/81) Added `agent.existingConfigMap` to skip rendering the ConfigMap and use your own instead.
 
 # 101.1.7
 - Upgraded the container-agent app image to version `3.1.8`

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.agent.resourceClasses }}
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -22,3 +23,4 @@ data:
     serviceContainers:
       {{- toYaml .Values.agent.serviceContainers | nindent 6 }}
     {{- end }}
+{{- end }}

--- a/templates/configmap.yaml
+++ b/templates/configmap.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.agent.resourceClasses }}
+{{- if and .Values.agent.resourceClasses (not .Values.agent.existingConfigMap) }}
 apiVersion: v1
 kind: ConfigMap
 metadata:

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       volumes:
         - name: taskpod-config
           configMap:
-            name: {{ include "container-agent.fullname" . }}
+            name: {{ .Values.agent.existingConfigMap | default (include "container-agent.fullname" .) }}
       containers:
         - name: {{ .Chart.Name }}
           {{- with .Values.agent.image }}

--- a/tests/configmap_test.yaml
+++ b/tests/configmap_test.yaml
@@ -101,3 +101,13 @@ tests:
     asserts:
      - hasDocuments:
         count: 0
+
+  - it: should be empty when existingConfigMap is set
+    set:
+      agent.resourceClasses:
+        acme-corp/road-runner:
+          token: shhh-its-a-secret
+      agent.existingConfigMap: my-custom-configmap
+    asserts:
+      - hasDocuments:
+          count: 0

--- a/tests/configmap_test.yaml
+++ b/tests/configmap_test.yaml
@@ -94,3 +94,10 @@ tests:
                 requests:
                   cpu: 100m
                   memory: 128Mi
+
+  - it: should be empty when no resourceClasses are set
+    set:
+      agent.resourceClasses: {}
+    asserts:
+     - hasDocuments:
+        count: 0

--- a/values.yaml
+++ b/values.yaml
@@ -191,6 +191,7 @@ agent:
 
   # -- Resource class settings. The tokens specified here will be used to claim tasks & the tasks
   # will be launched with the configured configs
+  # If you leave this unset you must provide your own configmap named {{ include "container-agent.fullname" . }}
   # Ref: https://circleci.com/docs/container-runner/#resource-class-configuration-custom-pod
   resourceClasses: {}
     # circleci-runner/resourceClass:

--- a/values.yaml
+++ b/values.yaml
@@ -189,9 +189,12 @@ agent:
   # As Kubernetes does not allow / in secret keys, a period (.) should be substituted instead
   customSecret: ""
 
+  # -- Option to use an existing ConfigMap instead of creating one from resourceClasses.
+  # If set, no ConfigMap will be rendered by this chart.
+  existingConfigMap: ""
+
   # -- Resource class settings. The tokens specified here will be used to claim tasks & the tasks
   # will be launched with the configured configs
-  # If you leave this unset you must provide your own configmap named {{ include "container-agent.fullname" . }}
   # Ref: https://circleci.com/docs/container-runner/#resource-class-configuration-custom-pod
   resourceClasses: {}
     # circleci-runner/resourceClass:


### PR DESCRIPTION
:gear: **Issue**

*Ticket/s*:  https://circleci.atlassian.net/browse/ONPREM-2396

:gear: **Change** 

Skips rendering the built-in ConfigMap when `agent.existingConfigMap` is set, allowing users to provide a templated ConfigMap via their own Helm toolchain. There are also corresponding application changes in container-agent to enable hot-reloading the specified ConfigMap: https://github.com/circleci/circleci-runner/pull/1103

This is related to issue #80. I built upon @from_nibly's PR #81 to have this as an explicit value, following the conventions we use elsewhere in the chart. 

<!-- Why the change? Please reference the ticket and AC if it exists -->
<!-- Include type of change; bug fix, new feature, breaking change, documentation, security -->
Change Type: 

AC:

:white_check_mark: **Fix**

<!-- How did you fix the issue? -->

:question: **Tests**

<!-- Enumerate what you tested here. We 💖 screenshots and issue specific tests! -->

- [x] Tests for new feature and update for changes
- [x] Linting passes and/or formatting matches the standard of the repo

Screenshot demonstrating using a custom CM with container runner + hot-reloading it:
<img width="1924" height="1089" alt="Screenshot 2026-03-16 at 9 50 29 AM" src="https://github.com/user-attachments/assets/8862806a-5052-465b-8bc6-67e9936552ab" />

🗒️ **Documentation**

<!-- Did you update related documentation -->

- [x] Updated related documentation (if applicable).
- [x] Updated Change log (if exists)
