### PR TITLE
[ONPREM-3245] Prepare 101.1.8 release

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -4,6 +4,6 @@ description: For deploying a CircleCI Container Agent
 icon: https://raw.githubusercontent.com/circleci/media/master/logo/build/horizontal_dark.1.png
 type: application
 
-version: "101.1.7"
-appVersion: "3.1.8"
+version: "101.1.8"
+appVersion: "3.1.9"
 kubeVersion: ">= 1.25-0"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 For deploying a CircleCI Container Agent
 
-![Version: 101.1.7](https://img.shields.io/badge/Version-101.1.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.8](https://img.shields.io/badge/AppVersion-3.1.8-informational?style=flat-square)
+![Version: 101.1.8](https://img.shields.io/badge/Version-101.1.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 3.1.9](https://img.shields.io/badge/AppVersion-3.1.9-informational?style=flat-square)
 
 ## Support
 
@@ -69,7 +69,7 @@ The command removes all the Kubernetes objects associated with the chart and del
 | agent.gc.enabled | bool | `true` | Enable garbage collection (GC) of Kubernetes objects such as Pods or Secrets left over from CircleCI tasks. Dangling objects may occur if container runner is forcefully deleted, causing the task state-tracking to be lost. GC will only remove objects labelled with `app.kubernetes.io/managed-by=circleci-container-agent`. |
 | agent.gc.interval | string | `"3m"` | Frequency of GC runs. Adjust this to balance minimal lingering K8s resources vs. system load. Infrequent runs may reduce the load but could result in excess K8s resources, while frequent runs help minimize resources but could increase system load. |
 | agent.gc.threshold | string | `"5h5m"` | The age of a Kubernetes object managed by container agent before GC deletes it. This value should be slightly longer than the `agent.maxRunTime` to prevent premature removal. GC may remove some objects sooner than this threshold, such as task Pod containers that fail their liveness probe. |
-| agent.image | object | `{"digest":"","pullPolicy":"Always","registry":"","repository":"circleci/runner-agent","tag":"kubernetes-3.1.8-8524-872f9d7"}` | Agent image settings. NOTE: Setting an image digest will take precedence over the image tag |
+| agent.image | object | `{"digest":"","pullPolicy":"Always","registry":"","repository":"circleci/runner-agent","tag":"kubernetes-3.1.9-9141-f95ed2b"}` | Agent image settings. NOTE: Setting an image digest will take precedence over the image tag |
 | agent.livenessProbe | object | `{"failureThreshold":5,"httpGet":{"path":"/live","port":7623,"scheme":"HTTP"},"initialDelaySeconds":10,"periodSeconds":10,"successThreshold":1,"timeoutSeconds":1}` | Liveness and readiness probe values Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#container-probes |
 | agent.log.format | string | `"json"` | Set the logging format for the container-agent app. Possible values are `text`, `color`, `json`, and `none`. |
 | agent.log.level | string | `"info"` | Set the logging level for the container-agent app. Possible values are `debug`, `info`, `warn`, and `error`. Note: this setting isn't to be confused with the [logging sidecar container](https://circleci.com/docs/container-runner/#logging-containers) which is configured under the top-level `logging` key. |
@@ -103,10 +103,10 @@ The command removes all the Kubernetes objects associated with the chart and del
 | agent.ssh.startPort | int | `54782` | Define the start port for SSH. This, combined with `agent.ssh.numPorts`, is used to define a range of ports. Be aware that you may need to configure your firewall or security groups to allow this port range. |
 | agent.terminationGracePeriodSeconds | int | `18300` | Tasks are drained during the termination grace period, so this should be sufficiently long relative to the maximum run time to ensure graceful shutdown |
 | agent.tolerations | list | `[]` | Node tolerations for agent scheduling to nodes with taints Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/ |
-| logging | object | `{"image":{"registry":"","repository":"circleci/logging-collector","tag":"3.1.7-7995-c2d711f"},"rbac":{"create":true,"role":{"name":"logging-collector","rules":[]}},"serviceAccount":{"annotations":{},"create":true,"name":"logging-collector","secret":{"name":"logging-collector-token"}}}` | Configuration values for the logging containers. These containers run alongside service containers and stream their logs to the CircleCI UI |
+| logging | object | `{"image":{"registry":"","repository":"circleci/logging-collector","tag":"3.1.9-9141-f95ed2b"},"rbac":{"create":true,"role":{"name":"logging-collector","rules":[]}},"serviceAccount":{"annotations":{},"create":true,"name":"logging-collector","secret":{"name":"logging-collector-token"}}}` | Configuration values for the logging containers. These containers run alongside service containers and stream their logs to the CircleCI UI |
 | logging.image.registry | string | `""` | Container registry for the logging collector image |
 | logging.image.repository | string | `"circleci/logging-collector"` | Repository name for the logging collector image |
-| logging.image.tag | string | `"3.1.7-7995-c2d711f"` | Image tag for the logging collector. Should match container agent version to ensure compatibility. |
+| logging.image.tag | string | `"3.1.9-9141-f95ed2b"` | Image tag for the logging collector. Should match container agent version to ensure compatibility. |
 | logging.rbac | object | `{"create":true,"role":{"name":"logging-collector","rules":[]}}` | RBAC configuration for the logging collector service account |
 | logging.rbac.create | bool | `true` | Whether to create RBAC resources |
 | logging.rbac.role.name | string | `"logging-collector"` | Name of the role |

--- a/changelog.md
+++ b/changelog.md
@@ -2,7 +2,9 @@
 
 # Edge
 
-[#81](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/81) Added `agent.existingConfigMap` to skip rendering the ConfigMap and use your own instead.
+# 101.1.8
+- Upgraded the container-agent app image to version `3.1.9`
+- [#103](https://github.com/CircleCI-Public/container-runner-helm-chart/pull/103) Added `agent.existingConfigMap` to skip rendering the ConfigMap and use your own instead.
 
 # 101.1.7
 - Upgraded the container-agent app image to version `3.1.8`

--- a/values.yaml
+++ b/values.yaml
@@ -12,7 +12,7 @@ agent:
     registry: ""
     repository: "circleci/runner-agent"
     pullPolicy: Always
-    tag: "kubernetes-3.1.8-8524-872f9d7"
+    tag: "kubernetes-3.1.9-9141-f95ed2b"
     digest: ""
 
   pullSecrets: []
@@ -341,7 +341,7 @@ logging:
     # -- Repository name for the logging collector image
     repository: "circleci/logging-collector"
     # -- Image tag for the logging collector. Should match container agent version to ensure compatibility.
-    tag: 3.1.7-7995-c2d711f
+    tag: 3.1.9-9141-f95ed2b
 
   # -- Service account for the logging collector container that gets mounted in task pods
   # when service containers are present. Requires minimal permissions to collect service container logs.


### PR DESCRIPTION
- Upgraded the container-agent app image to version 3.1.9
- Updated agent image to kubernetes-3.1.9-9141-f95ed2b
- Updated logging-collector image to 3.1.9-9141-f95ed2b
